### PR TITLE
Handle removal of django.utils.importlib

### DIFF
--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -1,6 +1,10 @@
 from django import template
 from django.template.loader import render_to_string, TemplateDoesNotExist
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 register = template.Library()
 


### PR DESCRIPTION
Django 1.8 removed django.utils.importlib as importlib is incuded in native Python 2.7.
